### PR TITLE
Fix OSTranslate32 signature

### DIFF
--- a/docs/reference/Func/OSTranslate32.md
+++ b/docs/reference/Func/OSTranslate32.md
@@ -8,8 +8,8 @@ DWORD OSTranslate32(
 	WORD  Charset,
 	char *In,
 	DWORD  InLength,
-	DWORD  OutSize,
-	char *OriginalOut);
+	char *OriginalOut,
+	DWORD  OutSize);
 ```
 **Description :**
 


### PR DESCRIPTION
Function signature has `OriginalOut` and `OutSize` switched in position.