### PR TITLE
Fix function definition for NIFFidnByKeyExtended4, add definition for NIFFindbyKeyCallback, and add file for NIFFINDBYKEYCTX

### DIFF
--- a/docs/reference/Data/NIFFINDBYKEYCTX.md
+++ b/docs/reference/Data/NIFFINDBYKEYCTX.md
@@ -1,0 +1,28 @@
+##### Data Type : Views
+##### NIFFINDBYKEYCTX - Structure of context for NIFFindbyKeyExtended4
+---
+```
+#include <nif.h>
+```
+
+**Definition :**
+```
+typedef struct NIFFindByKeyContext {
+	WORD	EntriesThisChunk;
+	WORD	wSizeOfChunk;
+	void	*SummaryBuffer;
+	MEMHANDLE hUserData;
+	DWORD	UserDataLen;
+	DWORD	TotalDataInBuffer;
+} NIFFINDBYKEYCTX;
+```
+
+**Description :**
+
+NIFFindByKeyExtended4 features a callback per chunk of summary, so the whole summary can
+	be returned while the Collection remains locked r/w
+
+
+**See Also :**
+[NIFFindByKeyExtended4](/domino-c-api-docs/reference/Func/NIFFindByKeyExtended4)
+---

--- a/docs/reference/Data/VARARG_PTR.md
+++ b/docs/reference/Data/VARARG_PTR.md
@@ -7,7 +7,7 @@
 
 **Definition :**
 ```
-#if defined(OSF) || (defined(NT) && defined(_ALPHA_))
+#if defined(OSF) || (defined(NT) && defined(_AMD64_)) || defined(LINUX) || defined(SOLARIS) || defined(MAC) || defined(AIX64)
 #include <stdarg.h>
 #define VARARG_PTR   va_list
 #elif defined(OS400)

--- a/docs/reference/Func/NIFFindByKeyExtended4.md
+++ b/docs/reference/Func/NIFFindByKeyExtended4.md
@@ -4,7 +4,7 @@
 ```
 #include <nif.h>
 STATUS NIFFindByKeyExtended4(
-
+	HCOLLECTION hCollection,
 	void *KeyBuffer,
 	DWORD  FindFlags,
 	DWORD  ReturnFlags,
@@ -31,6 +31,8 @@ the collated index).
 
 **Parameters :**
 Input :
+hCollection  - The handle of the collection you want to search.
+
 KeyBuffer  -  Address of "key" summary buffer.
 
 FindFlags  -  Find flags word (FIND_xxx).
@@ -44,6 +46,8 @@ pass NULL for other cases. (see nifnetods.h, FIND_BY_KEY_READENT_ARGS struct).
 
 NIFFindByKeyCallback  -  a callback function invoked for every full summary buffer 
 and at end.
+
+STATUS (LNCALLBACKPTR NIFFINDBYKEYPROC) (NIFFINDBYKEYCTX *Ctx);
 
 Ctx  -  handle to context structure (see nif.h) for said callback.
 
@@ -96,4 +100,5 @@ ReturnFlags, NULL,
 match (return) */
 ```
 **See Also :**
+[NIFFINDBYKEYCTX](/domino-c-api-docs/reference/Data/NIFFINDBYKEYCTX)
 ---


### PR DESCRIPTION
NIFFindByKeyExtended4 was missing the HCOLLECTION parameter, and there were no definitions for either the small NIFFindByKeyCallback function or the NIFFINDBYKEYCTX struct. This pulls those in from nif.h.